### PR TITLE
Clone the repo without requiring ssh keys

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -13,7 +13,7 @@ You can checkout the live version of the application at https://spring-ws-chat.h
 1. Clone the application
 
 ```bash
-git clone git@github.com:callicoder/spring-boot-websocket-chat-demo.git
+git clone https://github.com/callicoder/spring-boot-websocket-chat-demo.git
 ```
 
 2. Build and run the app using maven


### PR DESCRIPTION
I think it's better to give the http url to clone the repo. Using ssh keys may not work for some people.